### PR TITLE
Use token instead of userId and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ The following gateways are provided by this package:
 
 Available configuration options:
 
-* userId (string, required)
-* password (string, required)
+* token (string, required)
 * entityId (string, required)
 * testMode (0/1, optional)
 

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -14,30 +14,19 @@ class Gateway extends AbstractGateway
     public function getDefaultParameters()
     {
         return array(
-            'userId' => '',
-            'password' => '',
+            'token' => '',
             'entityId' => ''
         );
     }
 
-    public function getUserId()
+    public function getToken()
     {
-        return $this->getParameter('userId');
+        return $this->getParameter('token');
     }
 
-    public function setUserId($value)
+    public function setToken($value)
     {
-        return $this->setParameter('userId', $value);
-    }
-
-    public function getPassword()
-    {
-        return $this->getParameter('password');
-    }
-
-    public function setPassword($value)
-    {
-        return $this->setParameter('password', $value);
+        return $this->setParameter('token', $value);
     }
 
     public function getEntityId()

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -10,24 +10,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     protected $liveEndpoint = 'https://oppwa.com';
 
-    public function getUserId()
+    public function getToken()
     {
-        return $this->getParameter('userId');
+        return $this->getParameter('token');
     }
 
-    public function setUserId($value)
+    public function setToken($value)
     {
-        return $this->setParameter('userId', $value);
-    }
-
-    public function getPassword()
-    {
-        return $this->getParameter('password');
-    }
-
-    public function setPassword($value)
-    {
-        return $this->setParameter('password', $value);
+        return $this->setParameter('token', $value);
     }
 
     public function getEntityId()
@@ -53,22 +43,21 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     public function sendData($data)
     {
-        $authentication = array(
-            'authentication.userId' => $this->getUserId(),
-            'authentication.password' => $this->getPassword(),
-            'authentication.entityId' => $this->getEntityId()
+        $queryParams = array(
+            'entityId' => $this->getEntityId()
         );
 
-        $http_query = $this->getHttpMethod() == 'GET' ? '?' . http_build_query($authentication) : '';
+        $http_query = $this->getHttpMethod() == 'GET' ? '?' . http_build_query($queryParams) : '';
 
         $httpResponse = $this->httpClient->request(
             $this->getHttpMethod(),
             $this->getEndpoint() . $http_query,
             array(
-                'Content-Type' => 'application/x-www-form-urlencoded'
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Authorization' =>  'Bearer '.$this->getToken()
             ),
             http_build_query(array_merge(
-                $authentication,
+                $queryParams,
                 $data
             ))
         );


### PR DESCRIPTION
Oppwa is changing the authentication from userId and password to a token as authorization header.

You could migrate with:

```
$token = base64_encode($userId.'|'.$password);
```

Doc:
https://docs.oppwa.com/reference/parameters#authentication